### PR TITLE
Crossref doi report

### DIFF
--- a/templates/reporting/index.html
+++ b/templates/reporting/index.html
@@ -95,6 +95,13 @@
                                 <a href="{% url 'report_all_citations' %}">View Report</a>
                             </div>
                         </li>
+                        <li class="accordion-item" data-accordion-item>
+                            <a href="#" class="accordion-title">Crossref DOI URLs</a>
+                            <div class="accordion-content" data-tab-content>
+                                <p>Generates a TSV file that can be shared with Crossref to bulk update URLs linked to DOIs stored in Janeway</p>
+                                <a class="button" href="{% url 'reporting_crossref_dois' request.journal.pk %}">Download Report</a>
+                            </div>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,62 @@
+from io import StringIO
+
+from django.test import TestCase
+
+from identifiers import models as id_models
+from plugins.reporting import logic
+from submission import models as sm_models
+from utils.testing import helpers
+
+class TestCrossRefDOIRreport(TestCase):
+    def setUp(self):
+        self.press = helpers.create_press()
+        self.journal_one, self.journal_two = helpers.create_journals()
+        self.article_one, _= sm_models.Article.objects.get_or_create(
+            journal = self.journal_one,
+            title="Test article 1",
+            stage=sm_models.STAGE_PUBLISHED,
+        )
+        self.identifier_one, _ = id_models.Identifier.objects.get_or_create(
+            article=self.article_one,
+            id_type="doi",
+            identifier="10.0001/test"
+        )
+        self.article_two, _= sm_models.Article.objects.get_or_create(
+            journal = self.journal_two,
+            title="Test article two",
+            stage=sm_models.STAGE_PUBLISHED,
+        )
+        self.identifier_one, _ = id_models.Identifier.objects.get_or_create(
+            article=self.article_two,
+            id_type="doi",
+            identifier="10.0002/test"
+        )
+
+
+    def test_journal_tsv_report(self):
+        # Prepare
+        file_like = StringIO()
+        # Expect
+        expected = 'DOI\tURL\n10.0001/test\thttp://localhost/TST/article/id/1/\n'
+        # Do
+        logic.write_doi_tsv_report(file_like, journal=self.journal_one)
+        file_like.seek(0)
+        result = file_like.read()
+        # Assert
+        self.assertEqual(expected, result)
+
+
+
+    def test_press_tsv_report(self):
+        # Prepare
+        file_like = StringIO()
+        # Expect
+        expected = 'DOI\tURL\n10.0001/test\thttp://localhost/TST/article/id/3/\n10.0002/test\thttp://localhost/TSA/article/id/4/\n'
+        # Do
+        logic.write_doi_tsv_report(file_like)
+        file_like.seek(0)
+        result = file_like.read()
+        # Assert
+        self.assertEqual(expected, result)
+
+

--- a/urls.py
+++ b/urls.py
@@ -42,4 +42,7 @@ urlpatterns = [
     url(r'^citations/journal/(?P<journal_id>\d+)/article/(?P<article_id>\d+)/$',
         views.report_article_citing_works,
         name='report_article_citing_works'),
+    url(r'^crossref/(?P<journal_id>\d+|)$',
+        views.report_crossref_dois,
+        name='reporting_crossref_dois'),
 ]

--- a/views.py
+++ b/views.py
@@ -1,5 +1,6 @@
-from django.shortcuts import render, reverse, redirect, get_object_or_404
 from django.db.models import Q
+from django.http import HttpResponse
+from django.shortcuts import render, reverse, redirect, get_object_or_404
 from django.utils import translation
 
 from plugins.reporting import forms, logic
@@ -349,6 +350,22 @@ def report_article_citing_works(request, journal_id, article_id):
         'article': article,
         'links': article.articlelink_set.all(),
     }
-    
+
     return render(request, template, context)
+
+
+@editor_user_required
+def report_crossref_dois(request, journal_id=None):
+    """ A view that returns a report for Crossref mapping DOIs to URLS in tsv
+    :param journal_id: A journal ID to filter the DOI identifiers by
+    :return: an HttpResponse
+    """
+    journal = None
+    if journal_id:
+        journal = get_object_or_404(jm.Journal, pk=journal_id)
+
+    response = HttpResponse(content_type='text/tsv')
+    response['Content-Disposition'] = 'attachment; filename="DOI_urls.tsv"'
+    logic.write_doi_tsv_report(to_write=response, journal=journal)
+    return response
 


### PR DESCRIPTION
Adds a TSV export of DOIs to article/supplementary file URLs that can be provided to Crossref for bulk updating records