### PR TITLE
fix: correct date range filtering in workflow report

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -94,6 +94,21 @@ def get_start_and_end_months(request):
     return start_month, end_month, date_parts
 
 
+def get_month_range(date_parts):
+    """
+    Builds an inclusive (start, end) date range spanning whole months from the
+    start month to the end month. For example 2020-03 to 2021-06 covers
+    2020-03-01 through 2021-06-30 inclusive.
+    """
+    start = get_first_day(
+        date(int(date_parts['start_month_y']), int(date_parts['start_month_m']), 1)
+    )
+    end = get_last_day(
+        date(int(date_parts['end_month_y']), int(date_parts['end_month_m']), 1)
+    )
+    return start, end
+
+
 def get_articles(journal, start_date, end_date):
     dt = timezone.now()
 

--- a/views.py
+++ b/views.py
@@ -551,11 +551,9 @@ def report_workflow(request):
     start_month, end_month, date_parts = logic.get_start_and_end_months(
         request)
 
+    range_start, range_end = logic.get_month_range(date_parts)
     article_list = sm.Article.objects.filter(
-        date_published__year__gte=date_parts.get('start_month_y'),
-        date_published__month__gte=date_parts.get('start_month_m'),
-        date_published__year__lte=date_parts.get('start_month_y'),
-        date_published__month__lte=date_parts.get('end_month_m'),
+        date_published__date__range=(range_start, range_end),
     )
 
     if request.journal:


### PR DESCRIPTION
The workflow report (/plugins/reporting/workflow/) is meant to show articles published between two YYYY-MM months, but most ranges returned no results. For example 1990-01 to 2026-01 returned nothing on production.

  Two bugs in report_workflow:

  1. Year typo - the upper year bound used start_month_y instead of end_month_y, pinning results to the start year only.
  2. Decomposed year/month filtering - year and month were filtered as independent bounds, so the month constraint applied across every year. Any range where the start month was greater than the end month (e.g. 2024-06 → 2026-03) was always empty, since month >= 6 AND month <= 3 matches nothing.
  
   🤖 Generated with Claude Code